### PR TITLE
Remove irrelevant "esp8266_store_log_strings_in_flash" option in ESP32 config

### DIFF
--- a/src/esp32-example.yaml
+++ b/src/esp32-example.yaml
@@ -46,7 +46,6 @@ logger:
   level: WARN
   baud_rate: 0
   hardware_uart: UART1
-  esp8266_store_log_strings_in_flash: false
 
 # mqtt:
 #   broker: !secret mqtt_host


### PR DESCRIPTION
Fixes #2.