### PR TITLE
README.md: Remove POW-HVM5.5K-48V from compatibility list

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ All models that are supported by the [**WIFI-VM**](https://powmr.com/products/po
 - [**POW-HVM3.2H-24V**](https://powmr.com/products/all-in-one-inverter-charger-3000w-220vac-24vdc)
 - [**POW-HVM3.6M-24V**](https://powmr.com/products/hybrid-inverter-charger-3600w-220vac-24vdc)
 - [**POW-HVM4.2M-24V**](https://powmr.com/products/hybrid-inverter-charger-4200w-220vac-24vdc)
-- [**POW-HVM5.5K-48V**](https://powmr.com/products/all-in-one-inverter-charger-5500w-220vac-48vdc)
 - [**POW-HVM6.2M-48V**](https://powmr.com/products/hybrid-inverter-charger-6200w-220vac-48vdc)
 - [**POW-HVM8.2M**](https://powmr.com/products/hybrid-inverter-charger-8000w-220vac-48vdc)
 - [**POW-HVM10.2M**](https://powmr.com/products/hybrid-inverter-charger-10200w-200vac-48vdc)


### PR DESCRIPTION
On the official website it is listed as supported by the `WIFI-HVM-P1` device:

https://powmr.com/products/all-in-one-inverter-charger-5500w-220vac-48vdc
https://powmr.com/products/powmr-wifi-module-pro-plug05-wifi-hvm-p1

I accidentally added it in #7, probably because supported by the [other project](https://github.com/syssi/esphome-smg-ii).