### PR TITLE
Suggested Revisions and Additional Sensors

### DIFF
--- a/esphome/include/common.baseline.yaml
+++ b/esphome/include/common.baseline.yaml
@@ -1,0 +1,17 @@
+
+logger:
+  level: WARN
+  baud_rate: 0
+  logs:
+    component: ERROR # Fix for issue #4717 "Component xxxxxx took a long time for an operation"
+
+  # Enables mDNS Service
+mdns:
+  disabled: false
+
+  #  Enables the local webserver on the ESP device, upon port 80
+web_server:
+  port: 80
+
+#network:
+#  enable_ipv6: false

--- a/esphome/include/common.binary_sensor.yaml
+++ b/esphome/include/common.binary_sensor.yaml
@@ -1,0 +1,5 @@
+binary_sensor:
+  #  Creates the status sensor
+  - platform: status
+    name: 'Device Status'
+    entity_category: diagnostic

--- a/esphome/include/common.bme280.yaml
+++ b/esphome/include/common.bme280.yaml
@@ -1,0 +1,53 @@
+sensor:
+
+  # BME280 Sensor in I2C Port - Temperature
+  - platform: bme280
+    temperature:
+      name: "BME280 - Temperature"
+      id: bme280_temperature
+    pressure:
+      name: "BME280 - Pressure"
+      id: bme280_pressure
+    humidity:
+      name: "BME280 - Humidity (Relative)"
+      id: bme280_humidity
+    address: 0x76
+    update_interval: 15s
+
+  # BME280 Sensor in I2C Port - Absolute Humidity
+  - platform: absolute_humidity
+    name: "BME280 - Humidity (Absolute)"
+    temperature: bme280_temperature
+    humidity: bme280_humidity
+    equation: Wobus   # Wobus (Default), optional Tetens or Buck
+
+  # BME280 Sensor in I2C Port - Dew Point
+  - platform: template
+    name: "BME280 - Dew Point"
+    lambda: |-
+      return (243.5*(log(id(bme280_humidity).state/100)+((17.67*id(bme280_temperature).state)/
+      (243.5+id(bme280_temperature).state)))/(17.67-log(id(bme280_humidity).state/100)-
+      ((17.67*id(bme280_temperature).state)/(243.5+id(bme280_temperature).state))));
+    unit_of_measurement: °C
+    icon: 'mdi:thermometer-alert'
+
+  # BME280 Sensor in I2C Port - Equivalent Sea Level Pressure (based on 655m Goulburn North)
+  - platform: template
+    name: "BME280 - Equivalent Sea Level Pressure"
+    lambda: |-
+      const float STANDARD_ALTITUDE = 656; // in meters, see note
+      return id(bme280_pressure).state / powf(1 - ((0.0065 * STANDARD_ALTITUDE) /
+        (id(bme280_temperature).state + (0.0065 * STANDARD_ALTITUDE) + 273.15)), 5.257); // in hPa
+    update_interval: 15s
+    unit_of_measurement: 'hPa'
+
+   # Only Altitude OR Equivalent Sea Level Pressure can be run at one time, not both
+#  - platform: template
+#    name: "BME280 - Altitude"
+#    lambda: |-
+#      const float STANDARD_SEA_LEVEL_PRESSURE = 1014.1; //in hPa, see note
+#      return ((id(bme280_temperature).state + 273.15) / 0.0065) *
+#        (powf((STANDARD_SEA_LEVEL_PRESSURE / id(bme280_pressure).state), 0.190234) - 1); // in meter
+#    update_interval: 15s
+#    icon: 'mdi:signal'
+#    unit_of_measurement: 'm'

--- a/esphome/include/common.button.yaml
+++ b/esphome/include/common.button.yaml
@@ -1,0 +1,16 @@
+button:
+  #  Restart the ESP Device
+  - platform: restart
+    name: 'Restart ESP'
+
+  #  Reset the ESP Device
+  - platform: factory_reset
+    name: Restart ESP - Reset Settings
+    id: Reset
+    entity_category: config
+
+  #  Restart in Safe Mode
+  - platform: safe_mode
+    name: "Restart ESP - Safe Mode"
+    internal: false
+    entity_category: config

--- a/esphome/include/common.sensor.esp32.yaml
+++ b/esphome/include/common.sensor.esp32.yaml
@@ -1,0 +1,13 @@
+sensor:
+
+  #  Sensor uptime in seconds
+  - platform: uptime
+    name: "Uptime Seconds"
+    id: uptime_seconds
+    update_interval: 120s
+    entity_category: diagnostic
+    internal: True
+
+  # ESP32 Internal temperature
+  - platform: internal_temperature
+    name: "Device Temperature"

--- a/esphome/include/common.sensor.yaml
+++ b/esphome/include/common.sensor.yaml
@@ -1,0 +1,9 @@
+sensor:
+
+  #  Sensor uptime in seconds
+  - platform: uptime
+    name: "Uptime Seconds"
+    id: uptime_seconds
+    update_interval: 120s
+    entity_category: diagnostic
+    internal: True

--- a/esphome/include/common.text_sensor.yaml
+++ b/esphome/include/common.text_sensor.yaml
@@ -1,0 +1,79 @@
+text_sensor:
+  #  Creates a sensor showing when the device was last restarted
+  - platform: template
+    name: 'Device Last Restart'
+    id: device_last_restart
+    icon: mdi:clock
+    entity_category: diagnostic
+    update_interval: 5min
+#    device_class: timestamp
+
+  #  Creates sensor for tracking the WiFi IP address
+  - platform: wifi_info
+    ip_address:
+      name: 'WiFi IP Address'
+      icon: mdi:wifi
+      entity_category: diagnostic
+
+  #  Defines the WiFi SSID network to connect to
+    ssid:
+      name: 'WiFi SSID'
+      icon: mdi:wifi-strength-2
+      entity_category: diagnostic
+
+  #  Creates sensor for tracking the WiFi IP MAC address
+    mac_address:
+      name: 'WiFi MAC Address'
+      entity_category: diagnostic
+
+  #  Creates a sensor of the name of installed project
+  - platform: template
+    name: 'Project Name'
+    id: project_name
+    icon: "mdi:label-outline"
+    entity_category: diagnostic
+    lambda: |-
+      return {"${project_name}"};
+    update_interval: 6h
+
+  #  Creates a sensor of the version of installed project
+  - platform: template
+    name: 'Project Version'
+    id: project_version
+    icon: "mdi:label-outline"
+    entity_category: diagnostic
+    lambda: |-
+      return {"${project_version}"};
+    update_interval: 6h
+
+  #  Creates a sensor of the version of installed ESPHome version
+  - platform: version
+    name: "Project ESPHome Version"
+    hide_timestamp: true
+
+
+  #  Creates a sensor of the uptime of the device, in formatted days, hours, minutes and seconds
+  - platform: template
+    name: "Device Uptime"
+    update_interval: 5min
+    entity_category: diagnostic
+    lambda: |-
+      int seconds = (id(uptime_seconds).state);
+      int days = seconds / (24 * 3600);
+      seconds = seconds % (24 * 3600);
+      int hours = seconds / 3600;
+      seconds = seconds % 3600;
+      int minutes = seconds /  60;
+      seconds = seconds % 60;
+      if ( days > 3650 ) {
+        return { "Starting up" };
+      } else if ( days ) {
+        return { (String(days) +"d " + String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
+      } else if ( hours ) {
+        return { (String(hours) +"h " + String(minutes) +"m "+ String(seconds) +"s").c_str() };
+      } else if ( minutes ) {
+        return { (String(minutes) +"m "+ String(seconds) +"s").c_str() };
+      } else {
+        return { (String(seconds) +"s").c_str() };
+      }
+    icon: mdi:clock-start

--- a/esphome/include/common.time.options
+++ b/esphome/include/common.time.options
@@ -1,0 +1,47 @@
+  #  Enable time component to reset energy at midnight
+time:
+  - platform: sntp
+    id: sntp_time
+  # Define the timezone of the device
+    timezone: "${timezone}"
+  # Change sync interval from default 5min
+    update_interval: 6h
+  # Set specific sntp servers to use
+    servers: 
+      - 2.au.pool.ntp.org
+      - 1.au.pool.ntp.org
+      - 0.au.pool.ntp.org
+  # Publish the time the device was last restarted
+    on_time_sync:
+      then:
+        # Update last restart time, but only once.
+        - if:
+            condition:
+              lambda: 'return id(device_last_restart).state == "";'
+            then:
+              - text_sensor.template.publish:
+                  id: device_last_restart
+                  state: !lambda 'return id(sntp_time).now().strftime("%a %d %b %Y - %I:%M:%S %p");'
+
+
+
+----------------------------------------------------------
+
+
+  #  Enable time component to reset energy at midnight
+time:
+  - platform: homeassistant
+    id: homeassistant_time
+    timezone: "${timezone}"
+#    update_interval: 6h
+  # Publish the time the device was last restarted
+    on_time_sync:
+      then:
+        # Update last restart time, but only once.
+        - if:
+            condition:
+              lambda: 'return id(device_last_restart).state == "";'
+            then:
+              - text_sensor.template.publish:
+                  id: device_last_restart
+                  state: !lambda 'return id(homeassistant_time).now().strftime("%a %d %b %Y - %I:%M:%S %p");'

--- a/esphome/include/common.time.yaml
+++ b/esphome/include/common.time.yaml
@@ -1,0 +1,17 @@
+  #  Enable time component to reset energy at midnight
+time:
+  - platform: homeassistant
+    id: hass_time
+    timezone: "${timezone}"
+    update_interval: "${sntp_update_interval}"
+  # Publish the time the device was last restarted
+    on_time_sync:
+      then:
+        # Update last restart time, but only once.
+        - if:
+            condition:
+              lambda: 'return id(device_last_restart).state == "";'
+            then:
+              - text_sensor.template.publish:
+                  id: device_last_restart
+                  state: !lambda 'return id(hass_time).now().strftime("%a %d %b %Y - %I:%M:%S %p");'

--- a/esphome/include/common.wifi.yaml
+++ b/esphome/include/common.wifi.yaml
@@ -1,0 +1,19 @@
+
+sensor:
+  # Reports the WiFi signal strength/RSSI in dB
+  - platform: wifi_signal
+    name: "WiFi Signal dB"
+    id: wifi_signal_db
+    update_interval: 5min
+    entity_category: "diagnostic"
+    internal: true
+
+  # Reports the WiFi signal strength in %
+  - platform: copy
+    source_id: wifi_signal_db
+    name: "WiFi Signal"
+    filters:
+      - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
+    unit_of_measurement: "%"
+    entity_category: "diagnostic"
+

--- a/examples/inverter-card-example.yaml
+++ b/examples/inverter-card-example.yaml
@@ -1,168 +1,130 @@
-type: custom:stack-in-card
-cards:
-  - type: conditional
-    conditions:
-      - entity: binary_sensor.powerwall_inverter_grid_active
-        state: unavailable
-    card:
-      type: markdown
-      content: |
-        <ha-alert alert-type="warning">Inverter is turned off</ha-alert>
-      style: |
-        ha-card {
-          margin: 0px 0;
-          border: 0;
-        }
-  - type: conditional
-    conditions:
-      - entity: binary_sensor.powerwall_inverter_grid_active
-        state_not: unavailable
-    card:
-      type: vertical-stack
-      cards:
-        - type: custom:sunsynk-power-flow-card
-          cardstyle: lite
-          show_solar: false
-          panel_mode: false
-          decimal_places: 3
-          no_card: true
-          card_mod:
-            style: |
-              ha-card {
-                margin-top: -5px !important;
-              }
-              .card {
-                box-shadow: none !important;
-              }
-          inverter:
-            modern: false
-            colour: grey
-            autarky: power
-            auto_scale: true
-            model: powmr
-            three_phase: false
-          battery:
-            energy: 2400
-            max_power: 2400
-            shutdown_soc: 0
-            colour: '#9A64A0'
-            show_daily: true
-            invert_power: true
-            show_absolute: true
-          solar:
-            show_daily: false
-            mppts: 0
-          load:
-            show_daily: true
-            max_power: 2500
-            auto_scale: true
-          grid:
-            max_power: 2500
-            show_daily_buy: true
-            show_daily_sell: false
-            show_nonessential: false
-          entities:
-            inverter_status_59: sensor.powerwall_inverter_charger_status
-            inverter_voltage_154: sensor.powerwall_inverter_load_voltage
-            inverter_current_164: sensor.powerwall_inverter_load_current
-            inverter_power_175: sensor.powerwall_inverter_load_power
-            load_frequency_192: sensor.powerwall_inverter_load_frequency
-            grid_connected_status_194: binary_sensor.powerwall_inverter_grid_active
-            grid_ct_power_172: sensor.powerwall_inverter_grid_power
-            grid_power_167: sensor.powerwall_inverter_grid_power
-            battery_voltage_183: sensor.powerwall_battery_total_voltage
-            battery_soc_184: sensor.powerwall_battery_state_of_charge
-            battery_power_190: sensor.powerwall_battery_composite_power
-            battery_current_191: sensor.powerwall_battery_composite_current
-            battery_temp_182: sensor.powerwall_battery_temperature_2
-            day_battery_charge_70: sensor.powerwall_battery_composite_charge_daily_energy
-            day_battery_discharge_71: sensor.powerwall_battery_composite_discharge_daily_energy
-            day_grid_import_76: sensor.powerwall_inverter_grid_daily_energy
-            day_load_energy_84: sensor.powerwall_inverter_load_daily_energy
-        - type: custom:stack-in-card
-          mode: vertical
-          no_card: true
-          card_mod:
-            style: |
-              ha-card {
-                margin-top: -10px !important;
-              }
-          cards:
-            - type: custom:tabbed-card
-              tabs:
-                - attributes:
-                    label: General
-                    icon: mdi:book
-                  card:
-                    type: grid
-                    square: false
-                    cards:
-                      - type: tile
-                        entity: binary_sensor.powerwall_inverter_on_battery
-                        name: On Battery
-                        no_card: true
-                      - type: tile
-                        entity: binary_sensor.powerwall_inverter_load_enabled
-                        name: Load Enabled
-                        no_card: true
-                      - type: tile
-                        entity: sensor.powerwall_inverter_load_percent
-                        name: Load
-                        no_card: true
-                    columns: 3
-                - attributes:
-                    label: Sensors
-                    icon: mdi:eye
-                  card:
-                    type: grid
-                    square: false
-                    cards:
-                      - type: tile
-                        entity: sensor.powerwall_inverter_charger_status
-                        name: Charger
-                        no_card: true
-                      - type: tile
-                        entity: sensor.powerwall_inverter_controller_temperature
-                        name: ESP Temp
-                        no_card: true
-                      - type: tile
-                        entity: sensor.powerwall_inverter_rssi
-                        name: RSSI
-                        no_card: true
-                      - type: tile
-                        entity: sensor.powerwall_inverter_uptime
-                        name: Uptime
-                        no_card: true
-                    columns: 2
-                - attributes:
-                    label: Controls
-                    icon: mdi:cog
-                  card:
-                    type: grid
-                    square: false
-                    columns: 2
-                    cards:
-                      - type: tile
-                        entity: select.powerwall_inverter_output_source_priority
-                        name: Output Source Priority
-                        no_card: true
-                      - type: tile
-                        entity: select.powerwall_inverter_charger_source_priority
-                        name: Charger Source Priority
-                        no_card: true
-                      - type: tile
-                        entity: select.powerwall_inverter_utility_charge_current
-                        name: Utility Charge Current
-                        no_card: true
-                      - type: tile
-                        entity: select.powerwall_inverter_overload_bypass
-                        name: Overload Bypass
-                        no_card: true
-                      - type: tile
-                        entity: select.powerwall_inverter_beep_on_primary_source_fail
-                        name: Beep On Source Fail
-                        no_card: true
-                      - type: tile
-                        entity: select.powerwall_inverter_buzzer_alarm
-                        name: Buzzer Alarm
-                        no_card: true
+type: custom:sunsynk-power-flow-card
+cardstyle: lite
+panel_mode: true
+large_font: false
+title: PowMr Inverter - Power Monitor
+title_size: 12px
+show_solar: true
+show_battery: true
+show_grid: true
+decimal_places: 2
+dynamic_line_width: true
+max_line_width: 8
+inverter:
+  modern: false
+  colour: grey
+  autarky: power
+  auto_scale: true
+  model: powmr
+  three_phase: false
+battery:
+  energy: 2400
+  max_power: 2400
+  shutdown_soc: 0
+  colour: '#9A64A0'
+  show_daily: true
+  invert_power: true
+  show_absolute: true
+  hide_soc: false
+  show_remaining_energy: true
+  dynamic_colour: true            
+  linear_gradient: true
+solar:
+  show_daily: false
+  mppts: 1
+  maxpower: your-panel-total-watts-here
+  pv1_name: Solar PV
+  auto_scale: true
+  display_mode: 2
+  dynamic_colour: true
+load:
+  show_daily: true
+  max_power: 2500
+  show_daily_aux: true
+  show_aux: false
+  invert_aux: false
+  show_absolute_aux: false
+  aux_name: Generator
+  aux_type: gen
+  aux_colour: '#5490c2'
+  aux_off_colour: brown
+  aux_loads: 0
+  aux_load1_icon: ''
+  aux_load2_icon: ''
+  animation_speed: 4
+  essential_name: Caravan
+  additional_loads: 3
+  load1_name: Kitchen
+  load2_name: Bedroom
+  load3_name: Lights
+  load1_icon: mdi:gas-burner
+  load2_icon: mdi:bed-outline
+  load3_icon: mdi:light-flood-down
+  load4_icon: ''
+  auto_scale: true
+  dynamic_icon: true
+  dynamic_colour: true
+  invert_load: false
+  aux_dynamic_colour: true
+grid:
+  grid_name: Utility Power
+  max_power: 2500
+  colour: '#FF2400'
+  export_colour: green
+  no_grid_colour: null
+  grid_off_colour: '#e7d59f'
+  show_daily_buy: true
+  show_daily_sell: false
+  show_nonessential: true
+  invert_grid: false
+  nonessential_name: Non Essential
+  nonessential_icon: none
+  additional_loads: 1
+  load1_name: AirCon
+  load2_name: EV
+  load1_icon: mdi:fan
+  load2_icon: mdi:car
+  animation_speed: 7
+  auto_scale: true
+  dynamic_icon: true
+  dynamic_colour: true
+  energy_cost_decimals: 3
+entities:
+  day_battery_charge_70: sensor.battery_charge_daily
+  day_battery_discharge_71: sensor.battery_discharge_daily
+  day_load_energy_84: sensor.powmr_inverter_load_consumed_daily
+  day_grid_import_76: sensor.powmr_inverter_grid_imported_daily
+  day_pv_energy_108: sensor.powmr_inverter_pv_yield_daily
+  day_aux_energy: sensor.aircon_energy_daily_kwh
+  inverter_voltage_154: sensor.powmr_inverter_load_voltage
+  load_frequency_192: sensor.powmr_inverter_load_frequency            
+  grid_power_169: sensor.powmr_inverter_load_consumed_daily
+  total_pv_generation: sensor.powmr_inverter_pv_yield_daily
+  inverter_current_164: sensor.powmr_inverter_load_current
+  inverter_power_175: sensor.powmr_inverter_load_power
+  inverter_status_59: sensor.powmr_inverter_charger_status
+  pv1_power_186: sensor.powmr_inverter_pv_power         
+  environment_temp: sensor.<YOUR-LOCATION>_temp
+  remaining_solar: sensor.energy_production_today_remaining            
+  pv1_voltage_109: sensor.powmr_inverter_pv_voltage
+  pv1_current_110: sensor.powmr_inverter_pv_current
+  battery_voltage_183: sensor.powmr_inverter_battery_voltage
+  battery_soc_184: sensor.powmr_inverter_battery_soc
+  battery_power_190: sensor.powmr_inverter_battery_power
+  battery_current_191: sensor.powmr_inverter_battery_current
+  essential_power: sensor.powmr_inverter_load_power
+  essential_load1: sensor.kitchen_active_power
+  essential_load2: sensor.bed_av__active_power
+  essential_load1_extra: sensor.kitchen_temperature
+  essential_load2_extra: sensor.bedroom_temperature
+  load_power_L1: sensor.powmr_inverter_load_power
+  nonessential_power: sensor.sunsynk_card_non_essential_active_power
+  non_essential_load1: null
+  non_essential_load2: null
+  non_essential_load3: null
+  grid_ct_power_172: sensor.powmr_inverter_grid_power
+  grid_connected_status_194: sensor.powmr_inverter_grid_active
+  aux_power_166: sensor.aircon_aux_active_power
+  aux_load1_extra: sensor.caravan_internal_temperature
+  aux_load2_extra: sensor.caravan_external_temperature
+  grid_voltage: sensor.powmr_inverter_grid_voltage 

--- a/examples/inverter-card-example.yaml
+++ b/examples/inverter-card-example.yaml
@@ -35,9 +35,12 @@ cards:
                 box-shadow: none !important;
               }
           inverter:
-            colour: orange
-            autarky: 'no'
+            modern: false
+            colour: grey
+            autarky: power
             auto_scale: true
+            model: powmr
+            three_phase: false
           battery:
             energy: 2400
             max_power: 2400

--- a/examples/powmr-inverter.yaml
+++ b/examples/powmr-inverter.yaml
@@ -2,6 +2,19 @@ substitutions:
   device_name: "powmr-inverter"
   node_name: "PowMr Inverter"
   node_id: powmr_inverter
+  device_description: "Monitor and control a PowMr inverter"
+  # Allows ESP device to be automatically lined to an 'Area' in Home Assistant. Typically used for areas such as 'Lounge Room', 'Kitchen' etc
+  ha_area: "Caravan"  
+  project_name: "odya.esphome-powmr-hybrid-inverter"
+  project_version: "1.3.3"
+  # Define a domain for this device to use. i.e. iot.home.lan (so device will appear as athom-smart-plug-v2.iot.home.lan in DNS/DHCP logs)
+  dns_domain: ""
+  # Set timezone of the smart plug. Useful if the plug is in a location different to the HA server. Can be entered in unix Country/Area format (i.e. "Australia/Sydney")
+  timezone: "Australia/Sydney"
+  time_update_interval: 6h
+  # Enables faster network connections, with last connected SSID being connected to and no full scan for SSID being undertaken
+  wifi_fast_connect: "true"   
+  #
   inverter_tx_pin: GPIO16
   inverter_rx_pin: GPIO17
   inverter_voltage_offset: "0"
@@ -16,7 +29,7 @@ substitutions:
 esp32:
   board: nodemcu-32s
   framework:
-    type: esp-idf
+    type: esp-idf    # Note: type arduino also works and is much easier and faster to compile
 
 packages:
   main: !include powmr-inverter/main.yaml
@@ -32,6 +45,19 @@ logger:
 time:
   - platform: homeassistant
     id: hass_time
+    timezone: "${timezone}"
+    update_interval: "${time_update_interval}"
+  # Publish the time the device was last restarted
+    on_time_sync:
+      then:
+        # Update last restart time, but only once.
+        - if:
+            condition:
+              lambda: 'return id(device_last_restart).state == "";'
+            then:
+              - text_sensor.template.publish:
+                  id: device_last_restart
+                  state: !lambda 'return id(hass_time).now().strftime("%a %d %b %Y - %I:%M:%S %p");'
 
 #web_server:
 #  port: 80

--- a/examples/powmr_utility_sensors.yaml
+++ b/examples/powmr_utility_sensors.yaml
@@ -16,25 +16,25 @@ utility_meter:
   battery_charge_daily:
     unique_id: battery_charge_daily
     name: Battery Charge Daily
-    source: sensor.powmr_inverter_battery_total_charge    
+    source: sensor.powmr_inverter_battery_daily_charge    
     cycle: daily
 
   battery_charge_weekly:
     unique_id: battery_charge_weekly
     name: Battery Charge Weekly
-    source: sensor.powmr_inverter_battery_total_charge
+    source: sensor.powmr_inverter_battery_daily_charge
     cycle: weekly
 
   battery_charge_monthly:
     unique_id: battery_charge_monthly
     name: Battery Charge Monthly
-    source: sensor.powmr_inverter_battery_total_charge    
+    source: sensor.powmr_inverter_battery_daily_charge    
     cycle: monthly      
 
   battery_charge_yearly:
     unique_id: battery_charge_yearly
     name: Battery Charge Yearly
-    source: sensor.powmr_inverter_battery_total_charge    
+    source: sensor.powmr_inverter_battery_daily_charge    
     cycle: yearly
 
 ####
@@ -42,24 +42,24 @@ utility_meter:
   battery_discharge_daily:
     unique_id: battery_discharge_daily
     name: Battery Discharge Daily
-    source: sensor.powmr_inverter_battery_total_discharge    
+    source: sensor.powmr_inverter_battery_daily_discharge    
     cycle: daily
 
   battery_discharge_weekly:
     unique_id: battery_discharge_weekly
     name: Battery Discharge Weekly
-    source: sensor.powmr_inverter_battery_total_discharge    
+    source: sensor.powmr_inverter_battery_daily_discharge    
     cycle: weekly
 
   battery_discharge_monthly:
     unique_id: battery_discharge_monthly
     name: Battery Discharge Monthly
-    source: sensor.powmr_inverter_battery_total_discharge
+    source: sensor.powmr_inverter_battery_daily_discharge
     cycle: monthly      
 
   battery_discharge_yearly:
     unique_id: battery_discharge_yearly
     name: Battery Discharge Yearly
-    source: sensor.powmr_inverter_battery_total_discharge
+    source: sensor.powmr_inverter_battery_daily_discharge
     cycle: yearly
 

--- a/examples/powmr_utility_sensors.yaml
+++ b/examples/powmr_utility_sensors.yaml
@@ -1,0 +1,65 @@
+
+template:
+
+########################################################################################
+#
+#  This file is used to create Daily / Weekly / Monthly / Yearly utility sensors, that
+#  track of kWh used for the various sensors over these times.
+#
+#  If wanting to also track the cost of these sensors, refer to using the 'Energy Meter'
+#  integration via HACS (and replace utilit_meter with energy_meter).
+#
+
+
+utility_meter:
+
+  battery_charge_daily:
+    unique_id: battery_charge_daily
+    name: Battery Charge Daily
+    source: sensor.powmr_inverter_battery_total_charge    
+    cycle: daily
+
+  battery_charge_weekly:
+    unique_id: battery_charge_weekly
+    name: Battery Charge Weekly
+    source: sensor.powmr_inverter_battery_total_charge
+    cycle: weekly
+
+  battery_charge_monthly:
+    unique_id: battery_charge_monthly
+    name: Battery Charge Monthly
+    source: sensor.powmr_inverter_battery_total_charge    
+    cycle: monthly      
+
+  battery_charge_yearly:
+    unique_id: battery_charge_yearly
+    name: Battery Charge Yearly
+    source: sensor.powmr_inverter_battery_total_charge    
+    cycle: yearly
+
+####
+
+  battery_discharge_daily:
+    unique_id: battery_discharge_daily
+    name: Battery Discharge Daily
+    source: sensor.powmr_inverter_battery_total_discharge    
+    cycle: daily
+
+  battery_discharge_weekly:
+    unique_id: battery_discharge_weekly
+    name: Battery Discharge Weekly
+    source: sensor.powmr_inverter_battery_total_discharge    
+    cycle: weekly
+
+  battery_discharge_monthly:
+    unique_id: battery_discharge_monthly
+    name: Battery Discharge Monthly
+    source: sensor.powmr_inverter_battery_total_discharge
+    cycle: monthly      
+
+  battery_discharge_yearly:
+    unique_id: battery_discharge_yearly
+    name: Battery Discharge Yearly
+    source: sensor.powmr_inverter_battery_total_discharge
+    cycle: yearly
+

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -1,12 +1,14 @@
 esphome:
   name: "${device_name}"
   friendly_name: "${node_name}"
-  comment: "Monitor and control a PowMr inverter"
+  comment: "${device_description}" 
+  area: "${ha_area}" 
+  name_add_mac_suffix: false  
   includes:
     - "${device_name}/helpers"
   project:
-    name: "odya.esphome-powmr-hybrid-inverter"
-    version: 1.3.3
+    name: "${project_name}"
+    version: "${project_version}"
 
 packages:
   inverter: !include {
@@ -19,6 +21,11 @@ packages:
 
 logger:
   baud_rate: 0
+  level: WARN
+  logs:
+    component: ERROR # Fix for issue #4717 "Component xxxxxx took a long time for an operation"  
+
+captive_portal:
 
 sensor:
   - platform: internal_temperature
@@ -26,3 +33,78 @@ sensor:
     update_interval: 10s
     state_class: measurement
     device_class: temperature
+
+  - platform: template
+    name: "PV Current"
+    id: pv_current
+    state_class: "measurement"
+    device_class: current
+    unit_of_measurement: "A"
+    accuracy_decimals: 1
+    icon: mdi:solar-power
+    lambda: |-
+      return id(pv_power).state / id(pv_voltage).state;
+
+#   Calculate the LIFETIME kWh CHARGED into the battery.
+  - platform: template
+    name: "Battery Total Charge"
+    id: battery_total_charge
+    unit_of_measurement: "kWh"
+    device_class: energy
+    state_class: total_increasing
+    icon: mdi:battery-plus-variant
+    lambda: |-
+      return id(battery_charge_current).state / id(battery_voltage).state;
+    filters:
+      # Multiplication factor from W to kW is 0.001
+      - multiply: 0.001
+
+#   Calculate the LIFETIME kWh DISCHARGED from the battery.
+  - platform: template
+    name: "Battery Total Discharge"
+    id: battery_total_discharge
+    unit_of_measurement: "kWh"
+    device_class: energy
+    state_class: total_increasing
+    icon: mdi:battery-minus-variant
+    lambda: |-
+      return id(battery_discharge_current).state / id(battery_voltage).state;
+    filters:
+      # Multiplication factor from W to kW is 0.001
+      - multiply: 0.001
+
+#   Use pv_power sensor to provide a Daily Total kWh produced by Solar Panels.
+  - platform: total_daily_energy
+    name: 'PV Yield Daily'
+    power_id: pv_power
+    unit_of_measurement: 'kWh'
+    state_class: total_increasing
+    device_class: energy
+    accuracy_decimals: 3
+    filters:
+      # Multiplication factor from W to kW is 0.001
+      - multiply: 0.001
+
+#   Use load_power sensor to provide a Daily Total kWh consumed by the inverters Load.
+  - platform: total_daily_energy
+    name: 'Load Consumed Daily'
+    power_id: load_power
+    unit_of_measurement: 'kWh'
+    state_class: total_increasing
+    device_class: energy
+    accuracy_decimals: 3
+    filters:
+      # Multiplication factor from W to kW is 0.001
+      - multiply: 0.001
+
+#   Use grid_power sensor to provide a Daily Total kWh consumed by the inverters Load.
+  - platform: total_daily_energy
+    name: 'Grid Imported Daily'
+    power_id: grid_power
+    unit_of_measurement: 'kWh'
+    state_class: total_increasing
+    device_class: energy
+    accuracy_decimals: 3
+    filters:
+      # Multiplication factor from W to kW is 0.001
+      - multiply: 0.001

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -54,7 +54,7 @@ sensor:
     state_class: total_increasing
     icon: mdi:battery-plus-variant
     lambda: |-
-      return id(battery_charge_current).state / id(battery_voltage).state;
+      return id(battery_charge_current).state * id(battery_voltage).state;
     filters:
       # Multiplication factor from W to kW is 0.001
       - multiply: 0.001
@@ -68,7 +68,7 @@ sensor:
     state_class: total_increasing
     icon: mdi:battery-minus-variant
     lambda: |-
-      return id(battery_discharge_current).state / id(battery_voltage).state;
+      return id(battery_discharge_current).state * id(battery_voltage).state;
     filters:
       # Multiplication factor from W to kW is 0.001
       - multiply: 0.001

--- a/src/modules/debug.yaml
+++ b/src/modules/debug.yaml
@@ -5,3 +5,4 @@ sensor:
   - platform: debug
     free:
       name: "Heap Free"
+    entity_category: diagnostic

--- a/src/modules/inverter.yaml
+++ b/src/modules/inverter.yaml
@@ -185,6 +185,7 @@ sensor:
 
   - platform: template
     name: "Battery Power"
+    id: battery_power
     unit_of_measurement: "W"
     device_class: power
     state_class: measurement

--- a/src/modules/inverter.yaml
+++ b/src/modules/inverter.yaml
@@ -155,6 +155,7 @@ sensor:
     accuracy_decimals: 1
     lambda: |-
       return swapBytes(x);
+    internal: true
 
   - platform: modbus_controller
     modbus_controller_id: smg_inverter
@@ -167,8 +168,10 @@ sensor:
     device_class: current
     state_class: measurement
     accuracy_decimals: 1
+    # Convert this value into a negative value, to allow 'battery_cirrent' to show a negative value & Battery Power to then show Charge/Discharge
     lambda: |-
-      return swapBytes(x);
+      return swapBytes(0 - x);
+    internal: true
 
   - platform: template
     name: "Battery Current"
@@ -179,13 +182,13 @@ sensor:
     accuracy_decimals: 1
     update_interval: ${update_interval}
     lambda: |-
-      return id(battery_charge_current).state - id(battery_discharge_current).state;
+      return id(battery_charge_current).state + id(battery_discharge_current).state;
     filters:
       - heartbeat: 10s
 
   - platform: template
-    name: "Battery Power"
-    id: battery_power
+    name: "Battery Charge / Discharge Power"
+    id: battery_charge_discharge_power
     unit_of_measurement: "W"
     device_class: power
     state_class: measurement


### PR DESCRIPTION
Hi @odya Here's a bunch of changes that you'll find handy, adding in a number of sensors and also tidying up the code to use more 'substitution' section references. Apart from Energy / Power sensors being added it also adds sensors for the ESP and telling when it was updated (in readable format, not 34590565 seconds format).

Also included some common files in /esphome/include that can be called to create a number of these sensors.

Notes:

The example card for SunSynk also needs to be updated, as it currently refers to Telsa Powerwall entities (nothing to do with Inverter = PowMr), and these then need to be published to SunSynk documentation (or update that to point to your examples file instead).